### PR TITLE
Allow specifying UUID

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+env:
+  COMPONENT_NAME: signalilo
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -24,3 +27,19 @@ jobs:
       - uses: snow-actions/eclint@v1.0.1
         with:
           args: 'check'
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        instance:
+          - defaults
+          - uuid
+    defaults:
+      run:
+        working-directory: ${{ env.COMPONENT_NAME }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ env.COMPONENT_NAME }}
+      - name: Compile component
+        run: make test -e instance=${{ matrix.instance }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL := bash
 .SUFFIXES:
 
 include Makefile.vars.mk
+include Makefile.additional.mk
 
 .PHONY: help
 help: ## Show this help

--- a/Makefile.additional.mk
+++ b/Makefile.additional.mk
@@ -1,0 +1,9 @@
+commodore_args += -a maxscale-$(instance)
+
+.PHONY: test-uuid
+test-uuid: instance = uuid
+test-uuid: test
+
+.PHONY: test-default
+test-default: instance = defaults
+test-default: test

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,7 @@ parameters:
     =_metadata: {}
     namespace: syn-signalilo
     alertmanager_token: ?{vaultkv:${cluster:tenant}/${cluster:name}/signalilo/alertmanager_token}
+    uuid: ~
     icinga:
       url: https://icinga.example.com:5665
       user: signalilo_icingauser

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -52,7 +52,11 @@ local deployment = kube.Deployment('signalilo') {
           signalilo: kube.Container('signalilo') {
             image: params.images.signalilo.image + ':' + params.images.signalilo.tag,
             env_+: std.prune(com.proxyVars {
-              SIGNALILO_UUID: inv.parameters.cluster.name,
+              SIGNALILO_UUID: if params.uuid == null
+              then
+                inv.parameters.cluster.name
+              else
+                params.uuid,
               SIGNALILO_ICINGA_HOSTNAME: if params.icinga.hostname == null
               then
                 error 'parameters.signalilo.icinga.hostname is required'

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,6 +16,14 @@ The namespace in which to deploy this component.
 type:: string
 default:: `?{vaultkv:${cluster:tenant}/${cluster:name}/signalilo/alertmanager_token}`
 
+== `uuid`
+
+[horizontal]
+type:: string
+default:: inv.parameters.cluster.name
+
+UUID which identifies the Signalilo instance.
+
 == `icinga`
 
 Configuration for the Icinga API to which alerts are forwarded by Signalilo

--- a/tests/uuid.yml
+++ b/tests/uuid.yml
@@ -1,0 +1,7 @@
+# Overwrite parameters here
+
+# parameters: {...}
+
+parameters:
+  signalilo:
+    uuid: test-1234


### PR DESCRIPTION
New parameter `signalilo.uuid` that allows specifying the UUID used in the `SIGNALILO_UUID` env var.


## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
